### PR TITLE
Create wrapper for event publisher

### DIFF
--- a/Api/AsyncEventPublisherInterface.php
+++ b/Api/AsyncEventPublisherInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MageOS\AsyncEvents\Api;
+
+interface AsyncEventPublisherInterface
+{
+    /**
+     * Publish an asynchronous event
+     *
+     * @param string $eventName
+     * @param array $data
+     * @return void
+     */
+    public function publish(string $eventName, array $data): void;
+}

--- a/Model/AsyncEventPublisher.php
+++ b/Model/AsyncEventPublisher.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MageOS\AsyncEvents\Model;
+
+use Magento\Framework\MessageQueue\PublisherInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use MageOS\AsyncEvents\Api\AsyncEventPublisherInterface;
+use MageOS\AsyncEvents\Helper\QueueMetadataInterface;
+
+class AsyncEventPublisher implements AsyncEventPublisherInterface
+{
+    /**
+     * @param PublisherInterface $publisher
+     * @param SerializerInterface $serializer
+     */
+    public function __construct(
+        private readonly PublisherInterface $publisher,
+        private readonly SerializerInterface$serializer
+    ) {
+    }
+
+    /**
+     * Publish an asynchronous event
+     *
+     * @param string $eventName
+     * @param array $data
+     * @return void
+     */
+    public function publish(string $eventName, array $data): void
+    {
+        $arguments = $this->serializer->serialize($data);
+
+        $data = [
+            $eventName,
+            $arguments,
+        ];
+
+        $this->publisher->publish(QueueMetadataInterface::EVENT_QUEUE, $data);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,9 @@
     <preference for="MageOS\AsyncEvents\Api\Data\AsyncEventSearchResultsInterface"
                 type="MageOS\AsyncEvents\Model\AsyncEventSearchResults"/>
 
+    <preference for="MageOS\AsyncEvents\Api\AsyncEventPublisherInterface"
+                type="MageOS\AsyncEvents\Model\AsyncEventPublisher"/>
+
     <!-- UI Component DataProviders -->
     <type name="MageOS\AsyncEvents\Model\ResourceModel\AsyncEvent\Grid\Collection">
         <arguments>


### PR DESCRIPTION
Publishing an asynchronous event could be improved a little bit for better DX.

Currently, it requires that the user to inject `\Magento\Framework\MessageQueue\PublisherInterface` and `\Magento\Framework\Serialize\SerializerInterface` to the source class and then publish to the event queue with the user being responsible to serialise the arguments data.

Example

```php
$this->publisher->publish(
  QueueMetadataInterface::EVENT_QUEUE,
  [
    'sales.order.created',
    $this->serializer->serialize(
      [
        'id' => $orderId
      ]
    )
]);
```

This works fine, however it could be improved by abstracting away the serialisation and the event queue.

This is the new proposed way to publish events. The user does not need to know which queue the module uses internally and also provides the publisher class with central control of serialisation.

```php
  $this->publisher->publish('sales.order.created', [ 'id' => $orderId ]);

```
