### PR TITLE
Fix undefined array key access

### DIFF
--- a/Model/AsyncEventPublisher.php
+++ b/Model/AsyncEventPublisher.php
@@ -24,15 +24,17 @@ class AsyncEventPublisher implements AsyncEventPublisherInterface
      *
      * @param string $eventName
      * @param array $data
+     * @param int $storeId
      * @return void
      */
-    public function publish(string $eventName, array $data): void
+    public function publish(string $eventName, array $data, int $storeId = 0): void
     {
         $arguments = $this->serializer->serialize($data);
 
         $data = [
             $eventName,
             $arguments,
+            $storeId
         ];
 
         $this->publisher->publish(QueueMetadataInterface::EVENT_QUEUE, $data);

--- a/Model/AsyncEventTriggerHandler.php
+++ b/Model/AsyncEventTriggerHandler.php
@@ -49,7 +49,7 @@ class AsyncEventTriggerHandler
             // In a future major version this will change to a schema type e.g: AsyncEventMessageInterface
             $eventName = $queueMessage[0];
             $output = $this->json->unserialize($queueMessage[1]);
-            $storeId = (int) $queueMessage[2] ?? 0;
+            $storeId = (int) ($queueMessage[2] ?? 0);
 
             $configData = $this->asyncEventConfig->get($eventName);
             $serviceClassName = $configData['class'];


### PR DESCRIPTION
* Fixed a bug that would cause `Warning: Undefined array key 2`
* Added option to pass scope id to publisher