### PR TITLE
Support client side rate limiting

### DIFF
--- a/.github/workflows/api-functional-tests.yml
+++ b/.github/workflows/api-functional-tests.yml
@@ -11,6 +11,7 @@ jobs:
 
     # Only run api tests on feature branches. Simple documentation updates, formatting can be ignored
     if: contains(github.head_ref, 'feature')
+    name: ${{ matrix.job_title }}
     strategy:
       fail-fast: true
       matrix:
@@ -25,6 +26,8 @@ jobs:
             redis: "redis:6.2"
             varnish: "varnish:7.0"
             nginx: "nginx:1.18"
+            job_title: "2.4.5"
+
           - magento: magento/project-community-edition:>=2.4.5 <2.4.6
             php: 8.1
             composer: 2
@@ -34,6 +37,7 @@ jobs:
             redis: "redis:6.2"
             varnish: "varnish:7.0"
             nginx: "nginx:1.18"
+            job_title: "2.4.6"
 
     services:
       elasticsearch:

--- a/.github/workflows/api-functional-tests.yml
+++ b/.github/workflows/api-functional-tests.yml
@@ -68,7 +68,7 @@ jobs:
           - 5672:5672
           - 15672:15672
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set PHP Version
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,6 +11,7 @@ jobs:
 
     # Only run integration tests on feature branches. Simple documentation updates, formatting can be ignored
     if: contains(github.head_ref, 'feature')
+    name: ${{ matrix.job_title }}
     strategy:
       fail-fast: true
       matrix:
@@ -25,6 +26,7 @@ jobs:
             redis: "redis:6.2"
             varnish: "varnish:7.0"
             nginx: "nginx:1.18"
+            job_title: "2.4.5"
           - magento: magento/project-community-edition:>=2.4.5 <2.4.6
             php: 8.1
             composer: 2
@@ -34,6 +36,7 @@ jobs:
             redis: "redis:6.2"
             varnish: "varnish:7.0"
             nginx: "nginx:1.18"
+            job_title: "2.4.6"
 
     services:
       elasticsearch:
@@ -68,7 +71,7 @@ jobs:
           - 5672:5672
           - 15672:15672
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set PHP Version
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -131,6 +131,9 @@ jobs:
           sed -i "s/'db-password' => '123123q'/'db-password' => 'password'/" etc/install-config-mysql.php.dist
           sed -i "s/'elasticsearch-host' => 'localhost'/'elasticsearch-host' => '127.0.0.1'/" etc/install-config-mysql.php.dist
           sed -i "s/'amqp-host' => 'localhost'/'amqp-host' => '127.0.0.1'/" etc/install-config-mysql.php.dist
+          sed -i "s/'consumers-wait-for-messages' => '0'/'consumers-wait-for-messages' => '1'/" etc/install-config-mysql.php.dist
+          mkdir etc/di/preferences/cli
+          cp ../../../vendor/mage-os/mageos-async-events/Test/_files/ce.php ./etc/di/preferences/cli
 
       - run: ../../../vendor/bin/phpunit ../../../vendor/mage-os/mageos-async-events/Test/Integration
         working-directory:  ../magento2/dev/tests/integration

--- a/Api/Data/ResultInterface.php
+++ b/Api/Data/ResultInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MageOS\AsyncEvents\Api\Data;
+
+interface ResultInterface
+{
+    public function getIsSuccessful(): bool;
+
+    public function setIsSuccessful(bool $isSuccessful): void;
+
+    public function getIsRetryable(): bool;
+
+    public function setIsRetryable(bool $isRetryable): void;
+
+    public function getRetryAfter(): int;
+
+    public function setRetryAfter(int $retryAfter): void;
+
+    public function isSuccessful(): bool;
+
+    public function isRetryable(): bool;
+}

--- a/Api/Data/ResultInterface.php
+++ b/Api/Data/ResultInterface.php
@@ -12,11 +12,7 @@ interface ResultInterface
 
     public function setIsRetryable(bool $isRetryable): void;
 
-    public function getRetryAfter(): int;
+    public function getRetryAfter(): ?int;
 
     public function setRetryAfter(int $retryAfter): void;
-
-    public function isSuccessful(): bool;
-
-    public function isRetryable(): bool;
 }

--- a/Api/Data/ResultInterface.php
+++ b/Api/Data/ResultInterface.php
@@ -1,18 +1,53 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MageOS\AsyncEvents\Api\Data;
 
 interface ResultInterface
 {
+    /**
+     * Getter for is_successful
+     *
+     * @return bool
+     */
     public function getIsSuccessful(): bool;
 
+    /**
+     * Setter for is_successful
+     *
+     * @param bool $isSuccessful
+     * @return void
+     */
     public function setIsSuccessful(bool $isSuccessful): void;
 
+    /**
+     * Getter for is_retryable
+     *
+     * @return bool
+     */
     public function getIsRetryable(): bool;
 
+    /**
+     * Setter for is_retryable
+     *
+     * @param bool $isRetryable
+     * @return void
+     */
     public function setIsRetryable(bool $isRetryable): void;
 
+    /**
+     *  Getter for retry_after
+     *
+     * @return int|null
+     */
     public function getRetryAfter(): ?int;
 
+    /**
+     * Setter for retry_after
+     *
+     * @param int $retryAfter
+     * @return void
+     */
     public function setRetryAfter(int $retryAfter): void;
 }

--- a/Api/RetryManagementInterface.php
+++ b/Api/RetryManagementInterface.php
@@ -6,7 +6,7 @@ interface RetryManagementInterface
 {
     public function init(int $subscriptionId, mixed $data, string $uuid): void;
 
-    public function place(int $deathCount, int $subscriptionId, mixed $data, string $uuid, int $backoff = 0): void;
+    public function place(int $deathCount, int $subscriptionId, mixed $data, string $uuid, ?int $backoff): void;
 
     public function kill(int $subscriptionId, mixed $data): void;
 }

--- a/Api/RetryManagementInterface.php
+++ b/Api/RetryManagementInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MageOS\AsyncEvents\Api;
+
+interface RetryManagementInterface
+{
+    public function init(int $subscriptionId, mixed $data, string $uuid): void;
+
+    public function place(int $deathCount, int $subscriptionId, mixed $data, string $uuid, int $backoff = 0): void;
+
+    public function kill(int $subscriptionId, mixed $data): void;
+}

--- a/Helper/NotifierResult.php
+++ b/Helper/NotifierResult.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace MageOS\AsyncEvents\Helper;
 
 use Magento\Framework\DataObject;
+use MageOS\AsyncEvents\Api\Data\ResultInterface;
 
-class NotifierResult extends DataObject
+class NotifierResult extends DataObject implements ResultInterface
 {
     private const SUCCESS = 'success';
     private const SUBSCRIPTION_ID = 'subscription_id';
     private const RESPONSE_DATA = 'response_data';
     private const UUID = 'uuid';
     private const DATA = 'data';
+    private const IS_RETRYABLE = 'is_retryable';
+    private const RETRY_AFTER = 'retry_after';
 
     /**
      * Getter for success
@@ -117,5 +120,35 @@ class NotifierResult extends DataObject
     public function setAsyncEventData(array $eventData): void
     {
         $this->setData(self::DATA, $eventData);
+    }
+
+    public function getIsSuccessful(): bool
+    {
+        return $this->getSuccess();
+    }
+
+    public function setIsSuccessful(bool $isSuccessful): void
+    {
+        $this->setSuccess($isSuccessful);
+    }
+
+    public function getIsRetryable(): bool
+    {
+        return (bool) $this->getData(self::IS_RETRYABLE);
+    }
+
+    public function setIsRetryable(bool $isRetryable): void
+    {
+        $this->setData(self::IS_RETRYABLE, $isRetryable);
+    }
+
+    public function getRetryAfter(): ?int
+    {
+        return $this->getData(self::RETRY_AFTER);
+    }
+
+    public function setRetryAfter(int $retryAfter): void
+    {
+        $this->setData(self::RETRY_AFTER, $retryAfter);
     }
 }

--- a/Service/AsyncEvent/EventDispatcher.php
+++ b/Service/AsyncEvent/EventDispatcher.php
@@ -63,7 +63,7 @@ class EventDispatcher
 
             $notifier = $this->notifierFactory->create($handler);
 
-            $response = $notifier->notify(
+            $result = $notifier->notify(
                 $asyncEvent,
                 [
                     'data' => $output
@@ -71,11 +71,11 @@ class EventDispatcher
             );
 
             $uuid = $this->identityService->generateId();
-            $response->setUuid($uuid);
+            $result->setUuid($uuid);
 
-            $this->log($response);
+            $this->log($result);
 
-            if (!$response->getSuccess()) {
+            if (!$result->getIsSuccessful() && $result->getIsRetryable()) {
                 $this->retryManager->init($asyncEvent->getSubscriptionId(), $output, $uuid);
             }
         }

--- a/Service/AsyncEvent/HttpNotifier.php
+++ b/Service/AsyncEvent/HttpNotifier.php
@@ -82,12 +82,12 @@ class HttpNotifier implements NotifierInterface
                 $notifierResult->setResponseData($exceptionMessage);
                 $notifierResult->setIsRetryable(true);
 
-                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
                 if ($response->hasHeader('Retry-After')) {
                     $retryAfter = $response->getHeader('Retry-After')[0];
-                    $notifierResult->setRetryAfter((int) $retryAfter);
+                    if (is_numeric($retryAfter)) {
+                        $notifierResult->setRetryAfter((int) $retryAfter);
+                    }
                 }
-
             } else {
                 $notifierResult->setResponseData(
                     $exception->getMessage()

--- a/Service/AsyncEvent/NotifierInterface.php
+++ b/Service/AsyncEvent/NotifierInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MageOS\AsyncEvents\Service\AsyncEvent;
 
 use MageOS\AsyncEvents\Api\Data\AsyncEventInterface;
-use MageOS\AsyncEvents\Helper\NotifierResult;
+use MageOS\AsyncEvents\Api\Data\ResultInterface;
 
 interface NotifierInterface
 {
@@ -14,7 +14,7 @@ interface NotifierInterface
      *
      * @param AsyncEventInterface $asyncEvent
      * @param array $data
-     * @return NotifierResult
+     * @return ResultInterface
      */
-    public function notify(AsyncEventInterface $asyncEvent, array $data): NotifierResult;
+    public function notify(AsyncEventInterface $asyncEvent, array $data): ResultInterface;
 }

--- a/Test/Integration/FailoverTopologyTest.php
+++ b/Test/Integration/FailoverTopologyTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace MageOS\AsyncEvents\Test\Integration;
@@ -51,15 +50,15 @@ class FailoverTopologyTest extends TestCase
         /**
          * Place events at different death levels
          */
-        $this->retryManager->place(2, 1, 'test', 'uuid');
-        $this->retryManager->place(3, 1, 'test', 'uuid');
-        $this->retryManager->place(4, 1, 'test', 'uuid');
-        $this->retryManager->place(5, 1, 'test', 'uuid');
-        $this->retryManager->place(6, 1, 'test', 'uuid');
-        $this->retryManager->place(7, 1, 'test', 'uuid');
-        $this->retryManager->place(8, 1, 'test', 'uuid');
-        $this->retryManager->place(9, 1, 'test', 'uuid');
-        $this->retryManager->place(10, 1, 'test', 'uuid');
+        $this->retryManager->place(2, 1, 'test', 'uuid', null);
+        $this->retryManager->place(3, 1, 'test', 'uuid', null);
+        $this->retryManager->place(4, 1, 'test', 'uuid', null);
+        $this->retryManager->place(5, 1, 'test', 'uuid', null);
+        $this->retryManager->place(6, 1, 'test', 'uuid', null);
+        $this->retryManager->place(7, 1, 'test', 'uuid', null);
+        $this->retryManager->place(8, 1, 'test', 'uuid', null);
+        $this->retryManager->place(9, 1, 'test', 'uuid', null);
+        $this->retryManager->place(10, 1, 'test', 'uuid', null);
 
         $bindings = $this->helper->getExchangeBindings('event.failover');
 

--- a/Test/_files/ce.php
+++ b/Test/_files/ce.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Swap out Config for TestConfig during queue consumer run so `example.event` is available in Integration tests.
+ */
+
+return [
+    \MageOS\AsyncEvents\Model\Config::class => \MageOS\AsyncEvents\Test\Integration\TestConfig::class
+];

--- a/Test/_files/http_async_events.php
+++ b/Test/_files/http_async_events.php
@@ -11,7 +11,7 @@ $connection = $resource->getConnection();
 $connection->insertOnDuplicate('async_event_subscriber', [
     'subscription_id' => 1,
     'event_name' => 'example.event',
-    'recipient_url' => 'https://mock.codes/500',
+    'recipient_url' => 'https://mock.codes/503',
     'status' => 1,
     'metadata' => 'http',
     'verification_token' => 'secret',


### PR DESCRIPTION
Adds support for client side rate limiting.

For example, in a HTTP context, an overwhelmed consumer may be returning an explicit request to retry after `Delay` seconds or `Date`. We already have exponential back off to cool off during such scenarios but in a case where a "wait until" value is requested by the consumer it makes sense to respect that.

HTTP has the `Retry-After` response header. If using with the AWS SDK, we could attempt to catch a `ThrottlingException` (if it ever bubbles up)


Also improves the retry mechanism by retrying only retryable errors (example: `40x` are client side errors which cannot be retried)


And finally adds new data objects and interfaces and some minor code and style clean ups
