### PR TITLE
Search adapter fixes

### DIFF
--- a/Model/AsyncEventPublisher.php
+++ b/Model/AsyncEventPublisher.php
@@ -24,10 +24,10 @@ class AsyncEventPublisher implements AsyncEventPublisherInterface
      *
      * @param string $eventName
      * @param array $data
-     * @param int $storeId
+     * @param string $storeId
      * @return void
      */
-    public function publish(string $eventName, array $data, int $storeId = 0): void
+    public function publish(string $eventName, array $data, string $storeId = "0"): void
     {
         $arguments = $this->serializer->serialize($data);
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -97,24 +97,12 @@
     <type name="MageOS\AsyncEvents\Model\Indexer\AsyncEventSubscriber">
         <arguments>
             <argument name="dimensionProvider" xsi:type="object" shared="false">\MageOS\AsyncEvents\Model\Indexer\AsyncEventDimensionProvider</argument>
-            <argument name="adapter" xsi:type="object">asyncEventSearchAdapter</argument>
-            <argument name="indexStructure" xsi:type="object">asyncEventIndexStructure</argument>
         </arguments>
     </type>
 
     <type name="\MageOS\AsyncEvents\Model\Indexer\IndexStructure">
         <arguments>
             <argument name="scopeResolver" xsi:type="object" shared="false">\MageOS\AsyncEvents\Model\Resolver\AsyncEvent</argument>
-        </arguments>
-    </type>
-
-    <type name="Magento\Elasticsearch\Model\Adapter\BatchDataMapper\DataMapperFactory">
-        <arguments>
-            <argument name="dataMappers" xsi:type="array">
-                <item name="async_event" xsi:type="string">
-                    \MageOS\AsyncEvents\Model\Adapter\BatchDataMapper\AsyncEventLogMapper
-                </item>
-            </argument>
         </arguments>
     </type>
 
@@ -132,18 +120,4 @@
         <plugin name="map_string_scope_to_int"
                 type="MageOS\AsyncEvents\Plugin\MapStringScopeToInt"/>
     </type>
-
-    <virtualType name="asyncEventIndexStructure" type="Magento\Elasticsearch\Model\Indexer\IndexStructure">
-        <arguments>
-            <argument name="adapter" xsi:type="object">
-                asyncEventSearchAdapter
-            </argument>
-        </arguments>
-    </virtualType>
-
-    <virtualType name="asyncEventSearchAdapter" type="Magento\Elasticsearch\Model\Adapter\Elasticsearch">
-        <arguments>
-            <argument name="batchDocumentDataMapper" xsi:type="object">\MageOS\AsyncEvents\Model\Adapter\BatchDataMapper\AsyncEventLogMapper</argument>
-        </arguments>
-    </virtualType>
 </config>


### PR DESCRIPTION
Instantiating search adapter via DI causes DI to fail because the search adapter tries to connect to the search engine during DI bootstrap of the said object. In a setup where Elasticsearch / OpenSearch is not used this crashes the indexer when it attempts to run.

This PR addresses the issue and moves instantiating the adapter using a factory to after the config check so that in the cases where indexing is turned off via the setting it works as by returning early.