### PR TITLE
Add content-type header for the HTTP notifier

### DIFF
--- a/Service/AsyncEvent/HttpNotifier.php
+++ b/Service/AsyncEvent/HttpNotifier.php
@@ -48,7 +48,8 @@ class HttpNotifier implements NotifierInterface
                 self::HASHING_ALGORITHM,
                 $body,
                 $this->encryptor->decrypt($asyncEvent->getVerificationToken())
-            )
+            ),
+            'content-type' => 'application/json'
         ];
 
         $notifierResult = new NotifierResult();


### PR DESCRIPTION
Before v4, the HTTP notifier used Guzzle's `json` option to pass a php object and let it take care of serialization.

https://docs.guzzlephp.org/en/stable/request-options.html#json

> The json option is used to easily upload JSON encoded data as the body of a request. A Content-Type header of application/json will be added if no Content-Type header is already present on the message.

We no longer use the `json` option from Guzzle and pass our already CloudEvents compatible JSON into `body` we lost the content type header which was being automatically set by Guzzle.

This PR addresses this and adds the lost header :compass: 
