### PR TITLE
Get registered event sinks list

### DIFF
--- a/Service/AsyncEvent/NotifierFactory.php
+++ b/Service/AsyncEvent/NotifierFactory.php
@@ -30,4 +30,12 @@ class NotifierFactory implements NotifierFactoryInterface
 
         return $notifier;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSinks(): array
+    {
+        return array_keys($this->notifierClasses);
+    }
 }

--- a/Service/AsyncEvent/NotifierFactoryInterface.php
+++ b/Service/AsyncEvent/NotifierFactoryInterface.php
@@ -17,7 +17,7 @@ interface NotifierFactoryInterface
     /**
      * Get available event sinks
      *
-     * @return array
+     * @return string[]
      */
     public function getSinks(): array;
 }

--- a/Service/AsyncEvent/NotifierFactoryInterface.php
+++ b/Service/AsyncEvent/NotifierFactoryInterface.php
@@ -13,4 +13,11 @@ interface NotifierFactoryInterface
      * @return NotifierInterface
      */
     public function create(string $type): NotifierInterface;
+
+    /**
+     * Get available event sinks
+     *
+     * @return array
+     */
+    public function getSinks(): array;
 }


### PR DESCRIPTION
This is an idea to be able to retrieve registered event sinks info from the notifier factory itself without having to rely on plugins.

![image](https://github.com/user-attachments/assets/d7762c12-8173-4bc9-acd6-733a5ebdb491)

@avstudnitz This could potentially be used in the `AsyncEventsAdminUi` and other modules as necessary