### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/Model/Indexer/AsyncEventSubscriber.php
+++ b/Model/Indexer/AsyncEventSubscriber.php
@@ -75,8 +75,8 @@ class AsyncEventSubscriber implements
         private readonly AsyncEventLogMapper $loggerMapper,
         private readonly IndexStructureFactory $indexStructureFactory,
         private readonly array $data,
-        int $batchSize = null,
-        DeploymentConfig $deploymentConfig = null
+        ?int $batchSize = null,
+        ?DeploymentConfig $deploymentConfig = null
     ) {
         $this->batchSize = $batchSize ?? self::BATCH_SIZE;
         $this->deploymentConfig = $deploymentConfig ?: ObjectManager::getInstance()->get(DeploymentConfig::class);


### PR DESCRIPTION
See: [Fix PHP 8.4 deprecation: Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead](https://dev.to/gromnan/fix-php-84-deprecation-implicitly-marking-parameter-as-nullable-is-deprecated-the-explicit-nullable-type-must-be-used-instead-5gp3)

Use explicit nullable types.