### PR TITLE
🐛 Prevent adapter from connecting to search

### DIFF
--- a/Model/Indexer/LuceneSearch.php
+++ b/Model/Indexer/LuceneSearch.php
@@ -12,6 +12,7 @@ use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Ui\Component\Filters\FilterModifier;
 use Magento\Ui\Component\Filters\Type\Search;
+use MageOS\AsyncEvents\Helper\Config as AsyncEventsConfig;
 
 class LuceneSearch extends Search
 {
@@ -22,6 +23,7 @@ class LuceneSearch extends Search
      * @param FilterModifier $filterModifier
      * @param ConnectionManager $connectionManager
      * @param Config $config
+     * @param AsyncEventsConfig $asyncEventsConfig
      * @param array $components
      * @param array $data
      */
@@ -32,6 +34,7 @@ class LuceneSearch extends Search
         FilterModifier $filterModifier,
         private readonly ConnectionManager $connectionManager,
         private readonly Config $config,
+        private readonly AsyncEventsConfig $asyncEventsConfig,
         array $components = [],
         array $data = []
     ) {
@@ -49,38 +52,46 @@ class LuceneSearch extends Search
      */
     public function prepare(): void
     {
-        $client = $this->connectionManager->getConnection();
         $value = $this->getContext()->getRequestParam('search');
-        $indexPrefix = $this->config->getIndexPrefix();
-        $filter = $this->filterBuilder->setConditionType('in')
-            ->setField($this->getName());
 
-        if ($value === "") {
+        if (empty($value)) {
             return;
         }
 
-        try {
-            $rawResponse = $client->query(
-                [
-                    'index' => $indexPrefix . '_async_event_*',
-                    'q' => $value,
-                    // the default page size is 10. The highest limit is 10000. If we want to traverse further, we will
-                    // have to use the search after parameter. There are no plans to implement this right now.
-                    'size' => 100
-                ]
-            );
+        if ($this->asyncEventsConfig->isIndexingEnabled()) {
+            $client = $this->connectionManager->getConnection();
+            $indexPrefix = $this->config->getIndexPrefix();
+            $filter = $this->filterBuilder->setConditionType('in')
+                ->setField($this->getName());
 
-            $rawDocuments = $rawResponse['hits']['hits'] ?? [];
-            $asyncEventIds = array_column($rawDocuments, '_id');
+            try {
+                $rawResponse = $client->query(
+                    [
+                        'index' => $indexPrefix . '_async_event_*',
+                        'q' => $value,
+                        // the default page size is 10. The highest limit is 10000. If we want to traverse further, we
+                        // will  have to use the search after parameter. There are no plans to implement this right now.
+                        'size' => 100
+                    ]
+                );
 
-            if (!empty($asyncEventIds)) {
-                $filter->setValue($asyncEventIds);
-            } else {
+                $rawDocuments = $rawResponse['hits']['hits'] ?? [];
+                $asyncEventIds = array_column($rawDocuments, '_id');
+
+                if (!empty($asyncEventIds)) {
+                    $filter->setValue($asyncEventIds);
+                } else {
+                    $filter->setValue("0");
+                }
+            } catch (Exception) {
+                // If we're unable to connect to Elasticsearch, we'll return nothing
                 $filter->setValue("0");
             }
-        } catch (Exception) {
-            // If we're unable to connect to Elasticsearch, we'll return nothing
-            $filter->setValue("0");
+
+        } else {
+            $filter = $this->filterBuilder->setConditionType('like')
+                ->setField('serialized_data')
+                ->setValue($value);
         }
 
         $this->getContext()->getDataProvider()->addFilter($filter->create());

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -102,6 +102,7 @@
 
     <type name="\MageOS\AsyncEvents\Model\Indexer\IndexStructure">
         <arguments>
+            <argument name="adapter" xsi:type="object">\Magento\Elasticsearch\Model\Adapter\Elasticsearch\Proxy</argument>
             <argument name="scopeResolver" xsi:type="object" shared="false">\MageOS\AsyncEvents\Model\Resolver\AsyncEvent</argument>
         </arguments>
     </type>


### PR DESCRIPTION
Possible fix for #41  https://github.com/mage-os/mageos-async-events/issues/41