### PR TITLE
Increase target url length to Magentos max-varchar(1024)

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -4,7 +4,7 @@
     <table name="async_event_subscriber" charset="utf8mb4" collation="utf8mb4_unicode_ci">
         <column name="subscription_id" xsi:type="int" unsigned="true" identity="true" nullable="false"/>
         <column name="event_name" xsi:type="varchar" nullable="false"/>
-        <column name="recipient_url" xsi:type="varchar" nullable="false"/>
+        <column name="recipient_url" xsi:type="varchar" length="1024" nullable="false"/>
         <column name="verification_token" xsi:type="varchar" nullable="false"/>
         <column name="status" xsi:type="boolean" nullable="false" default="0"
                 comment="Whether the subscription is active or not"/>


### PR DESCRIPTION
In case of pretty long urls (>255), where you could not remove the parameters, it got truncated. This alt least increases the length to 1024 which is the Magento maximum for a varchar column. If more is needed, a type change is inevitable.

I was not aware that renaming the branch would close the PR. Original PR in question: https://github.com/mage-os/mageos-async-events/pull/47