### PR TITLE
Explicitly set default value to constructor argument

### DIFF
--- a/Model/Indexer/AsyncEventSubscriber.php
+++ b/Model/Indexer/AsyncEventSubscriber.php
@@ -74,7 +74,7 @@ class AsyncEventSubscriber implements
         private readonly ElasticsearchFactory $adapterFactory,
         private readonly AsyncEventLogMapper $loggerMapper,
         private readonly IndexStructureFactory $indexStructureFactory,
-        private readonly array $data,
+        private readonly array $data = [],
         ?int $batchSize = null,
         ?DeploymentConfig $deploymentConfig = null
     ) {


### PR DESCRIPTION
I stumbled over the follow error in system.log:

```
Type Error occurred when creating object: 
MageOS\AsyncEvents\Model\Indexer\AsyncEventSubscriber\Interceptor, 
MageOS\AsyncEvents\Model\Indexer\AsyncEventSubscriber\Interceptor::__construct(): 
Argument #9 ($data) must be of type array, null given
```

MageOS\AsyncEvents\Model\Indexer\AsyncEventSubscriber::__construct() has a required `array $data` at arg #9 with no default, and the module's etc/di.xml never configures $data. It's only ever populated at runtime by Magento\Indexer\Model\Indexer::getActionInstance(). Any other DI resolution resolves data to null.